### PR TITLE
Fix loading errors caused by inconsistent status codes

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -50,13 +50,19 @@ var
 	return -1;
 }
 , request_JSON = function (uri) {
-	var req = new XHR();
+	var req  = new XHR(),
+		data = {};
 	
 	// sadly, this has to be blocking to allow for a graceful degrading API
 	req.open("GET", uri, FALSE);
 	req.send(null);
 	
-	if (req.status !== 200) {
+	// Status codes can be inconsistent across browsers so we simply try to parse
+	// the response text and catch any errors. This deals with failed requests as
+	// well as malformed json files.
+	try {
+		data = JSON.parse(req.responseText);
+	} catch(e) {
 		// warn about error without stopping execution
 		setTimeout(function () {
 			// Error messages are not localized as not to cause an infinite loop
@@ -64,11 +70,9 @@ var
 			l10n_err.name = "Localization Error";
 			throw l10n_err;
 		}, 0);
-		
-		return {};
-	} else {
-		return JSON.parse(req.responseText);
 	}
+
+	return data;
 }
 , load = String_ctr[$to_locale_string] = function (data) {
 	// don't handle function.toLocaleString(indentationAmount:Number)


### PR DESCRIPTION
Status codes can be inconsistent across browsers so it is safer to base success/failure of loading a JSON file on being able to successfully parse it. This deals with failed requests (missing files) as well as malformed jSON files. Fixes #21
