### PR TITLE
Added `nb` locale

### DIFF
--- a/demo/localizations.js
+++ b/demo/localizations.js
@@ -55,6 +55,10 @@ String.toLocaleString({
 		"%title": "Norsk - Demo av l10n.js",
 		"%info": "Du ser den norske oversettelsen av denne siden."
 	},
+	"nb": {
+		"%title": "Norsk - Demo av l10n.js",
+		"%info": "Du ser den norske oversettelsen av denne siden."
+	},
 	"ru": {
 		"%title": "Русский - l10n.js демо",
 		"%info": "Вы просматриваете Русскую версию этой страницы."


### PR DESCRIPTION
Norwegian can go by the short name of "no" (Norwegian) or "nb" (Norwegian - Bokmål). Chrome on my mac reports with the later, thus the demo does not work.