### PR TITLE
Ability to manually define locale to use.

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -197,7 +197,9 @@ if (typeof XMLHttpRequest === undef_type && typeof ActiveXObject !== undef_type)
 }
 
 String_ctr[$default_locale] = String_ctr[$default_locale] || "";
-String_ctr[$locale] = nav && (nav.language || nav.userLanguage) || "";
+if (!String_ctr[$locale]) {
+	String_ctr[$locale] = nav && (nav.language || nav.userLanguage) || "";
+}
 
 if (typeof document !== undef_type) {
 	var


### PR DESCRIPTION
Hello,
This small commit allow to manually set String.locale before loading main script. If not set - old behavior will be used (autodetection by navigator language)